### PR TITLE
Excludes hardhat-diamond-abi/.* so no reprocessing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -196,7 +196,7 @@ export async function generateDiamondAbi(
     }
     
     // this should be the output filename, but this will work too
-    if (contractName.match("hardhat-diamond-abi\/.*")) {
+    if (contractName.startsWith(PLUGIN_NAME)) {
         continue;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,6 +194,11 @@ export async function generateDiamondAbi(
       log(`Skipping ${contractName} because it did matched an \`exclude\` pattern.`);
       continue;
     }
+    
+    // this should be the output filename, but this will work too
+    if (contractName.match("hardhat-diamond-abi\/.*")) {
+        continue;
+    }
 
     // debug(including contractName in Name ABI)
     log(`Including ${contractName} in your ${config.name} ABI.`);


### PR DESCRIPTION
This can be accomplished with the hardhat-config.ts file as well, but this is more transparent.

    exclude: ["hardhat-diamond-abi\/.*"],