### PR TITLE
fix: Avoid reprocessing the ABI created by plugin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -196,7 +196,7 @@ export async function generateDiamondAbi(
     }
     
     // this should be the output filename, but this will work too
-    if (contractName.match("hardhat-diamond-abi\/.*")) {
+    if (contractName.startsWith(PLUGIN_NAME)) {
         continue;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,6 +197,7 @@ export async function generateDiamondAbi(
 
     // this should be the output filename, but this will work too
     if (contractName.startsWith(PLUGIN_NAME)) {
+      log(`Skipping ${contractName} because it is the stub ABI produced by ${PLUGIN_NAME}.`);
       continue;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,6 +194,11 @@ export async function generateDiamondAbi(
       log(`Skipping ${contractName} because it did matched an \`exclude\` pattern.`);
       continue;
     }
+    
+    // this should be the output filename, but this will work too
+    if (contractName.match("hardhat-diamond-abi\/.*")) {
+        continue;
+    }
 
     // debug(including contractName in Name ABI)
     log(`Including ${contractName} in your ${config.name} ABI.`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,10 +194,10 @@ export async function generateDiamondAbi(
       log(`Skipping ${contractName} because it did matched an \`exclude\` pattern.`);
       continue;
     }
-    
+
     // this should be the output filename, but this will work too
     if (contractName.startsWith(PLUGIN_NAME)) {
-        continue;
+      continue;
     }
 
     // debug(including contractName in Name ABI)

--- a/test/fixture-projects/avoid-reprocessing/contracts/TestA.sol
+++ b/test/fixture-projects/avoid-reprocessing/contracts/TestA.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0;
+
+contract TestA {
+    function foo() public pure returns (bool) {
+        return true;
+    }
+}

--- a/test/fixture-projects/avoid-reprocessing/contracts/TestB.sol
+++ b/test/fixture-projects/avoid-reprocessing/contracts/TestB.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0;
+
+contract TestB {
+    function bar() public pure returns (bool) {
+        return false;
+    }
+}

--- a/test/fixture-projects/avoid-reprocessing/hardhat.config.ts
+++ b/test/fixture-projects/avoid-reprocessing/hardhat.config.ts
@@ -1,0 +1,20 @@
+// We load the plugin here.
+import type { HardhatUserConfig } from "hardhat/types";
+
+import "../../../";
+import { name } from "../../../package.json";
+
+const config: HardhatUserConfig = {
+  solidity: "0.8.10",
+  diamondAbi: {
+    name: "HardhatDiamond",
+    filter(abiElement, idx, abi, fullyQualifiedName) {
+      if (fullyQualifiedName.startsWith(name)) {
+        throw new Error("Saw our ABI in the output");
+      }
+      return true;
+    },
+  },
+};
+
+export default config;

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -267,5 +267,26 @@ describe("hardhat-diamond-abi", function () {
       const { abi } = await hre.artifacts.readArtifact(hre.config.diamondAbi.name);
       assert.sameMembers(getAbiNames(abi), ["foo", "baz", "bar", "baz"]);
     });
+
+    it.only("doesn't include our generated ABI when run again", async function () {
+      process.chdir(path.join(__dirname, "fixture-projects", "avoid-reprocessing"));
+
+      const hre = require("hardhat");
+
+      await hre.run(TASK_COMPILE);
+
+      const artifactExists = await hre.artifacts.artifactExists(hre.config.diamondAbi.name);
+      assert.isTrue(artifactExists);
+
+      try {
+        // We force a 2nd build because we don't change any code (but a normal project would)
+        await hre.run(TASK_COMPILE, { force: true });
+      } catch (err) {
+        assert.fail(err.message);
+      }
+
+      const { abi } = await hre.artifacts.readArtifact(hre.config.diamondAbi.name);
+      assert.sameMembers(getAbiNames(abi), ["foo", "bar"]);
+    });
   });
 });

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -268,7 +268,7 @@ describe("hardhat-diamond-abi", function () {
       assert.sameMembers(getAbiNames(abi), ["foo", "baz", "bar", "baz"]);
     });
 
-    it.only("doesn't include our generated ABI when run again", async function () {
+    it("doesn't include our generated ABI when run again", async function () {
       process.chdir(path.join(__dirname, "fixture-projects", "avoid-reprocessing"));
 
       const hre = require("hardhat");


### PR DESCRIPTION
If users of the plugin don't use include or exclude, the ABI generated by this plugin will be reprocessed whenever they make code changes. We need to skip that ABI always.

Closes #7 
Solved in #8 but I needed to add a new test and logging.