### PR TITLE
fix: Filter fallback & receive functions from the ABI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -228,7 +228,12 @@ export async function generateDiamondAbi(
           if (abiElement.type === "constructor") {
             return false;
           }
-
+          if (abiElement.type === "fallback") {
+            return false;
+          }
+          if (abiElement.type === "receive") {
+            return false;
+          }
           if (typeof config.filter === "function") {
             return config.filter(abiElement, index, abi, contractName);
           }

--- a/test/fixture-projects/hardhat-contracts-fallback/contracts/TestA.sol
+++ b/test/fixture-projects/hardhat-contracts-fallback/contracts/TestA.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0;
+
+contract TestA {
+    fallback() external payable {}
+
+    function foo() public pure returns (bool) {
+        return true;
+    }
+}

--- a/test/fixture-projects/hardhat-contracts-fallback/contracts/TestB.sol
+++ b/test/fixture-projects/hardhat-contracts-fallback/contracts/TestB.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0;
+
+contract TestB {
+    fallback() external payable {}
+
+    function bar() public pure returns (bool) {
+        return false;
+    }
+}

--- a/test/fixture-projects/hardhat-contracts-fallback/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-contracts-fallback/hardhat.config.ts
@@ -1,0 +1,13 @@
+// We load the plugin here.
+import type { HardhatUserConfig } from "hardhat/types";
+
+import "../../../";
+
+const config: HardhatUserConfig = {
+  solidity: "0.8.10",
+  diamondAbi: {
+    name: "HardhatDiamond",
+  },
+};
+
+export default config;

--- a/test/fixture-projects/hardhat-contracts-receive/contracts/TestA.sol
+++ b/test/fixture-projects/hardhat-contracts-receive/contracts/TestA.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0;
+
+contract TestA {
+    receive() external payable {}
+
+    function foo() public pure returns (bool) {
+        return true;
+    }
+}

--- a/test/fixture-projects/hardhat-contracts-receive/contracts/TestB.sol
+++ b/test/fixture-projects/hardhat-contracts-receive/contracts/TestB.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0;
+
+contract TestB {
+    receive() external payable {}
+
+    function bar() public pure returns (bool) {
+        return false;
+    }
+}

--- a/test/fixture-projects/hardhat-contracts-receive/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-contracts-receive/hardhat.config.ts
@@ -1,0 +1,13 @@
+// We load the plugin here.
+import type { HardhatUserConfig } from "hardhat/types";
+
+import "../../../";
+
+const config: HardhatUserConfig = {
+  solidity: "0.8.10",
+  diamondAbi: {
+    name: "HardhatDiamond",
+  },
+};
+
+export default config;

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -227,6 +227,32 @@ describe("hardhat-diamond-abi", function () {
       assert.sameMembers(getAbiNames(abi), ["foo", "bar"]);
     });
 
+    it("always removes receive when generating an artifact", async function () {
+      process.chdir(path.join(__dirname, "fixture-projects", "hardhat-contracts-receive"));
+
+      const hre = require("hardhat");
+
+      await hre.run(TASK_COMPILE);
+
+      const artifactExists = await hre.artifacts.artifactExists(hre.config.diamondAbi[0].name);
+      assert.isTrue(artifactExists);
+      const { abi } = await hre.artifacts.readArtifact(hre.config.diamondAbi[0].name);
+      assert.sameMembers(getAbiNames(abi), ["foo", "bar"]);
+    });
+
+    it("always removes fallback when generating an artifact", async function () {
+      process.chdir(path.join(__dirname, "fixture-projects", "hardhat-contracts-fallback"));
+
+      const hre = require("hardhat");
+
+      await hre.run(TASK_COMPILE);
+
+      const artifactExists = await hre.artifacts.artifactExists(hre.config.diamondAbi[0].name);
+      assert.isTrue(artifactExists);
+      const { abi } = await hre.artifacts.readArtifact(hre.config.diamondAbi[0].name);
+      assert.sameMembers(getAbiNames(abi), ["foo", "bar"]);
+    });
+
     it("includes events and errors when generating an artifact", async function () {
       process.chdir(path.join(__dirname, "fixture-projects", "hardhat-contracts-events-errors"));
 


### PR DESCRIPTION
Closes #13 

This filters `fallback` and `receive` functions from contracts. They can't be formatted via ethers, so I'm not sure they need to show up in the ABI at all.

When generating a Diamond ABI, this should only happen if you are processing your Diamond contract itself, which I don't recommend. I thought about implementing "Diamond detection" code that would throw an error, but we already filter constructors, so we can just filter these from the ABI as well.